### PR TITLE
Correction in the Error statement in cmdAdd

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -155,7 +155,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	netns, err := ns.GetNS(args.Netns)
 	if err != nil {
-		return fmt.Errorf("failed to open netns %q: %v", netns, err)
+		return fmt.Errorf("failed to open netns %q: %v", args.Netns, err)
 	}
 	defer netns.Close()
 


### PR DESCRIPTION
It should be args.Netns instead of netns.
