### PR TITLE
    Assign pf directly if we don't need vf

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ func (i *UnmarshallableInt) UnmarshalText(data []byte) error {
 type NetConf struct {
 	types.NetConf
 	Master string `json:"master"`
+	PFOnly bool   `json:"pfOnly"`
 }
 
 type NetArgs struct {


### PR DESCRIPTION
    For some scenarios, we don't need vf-dpdk(bandwidth allocation and orchestrate).
    Such as firewall, load-balancer and so on.
    For example, in a typical 3G/4G/5G base-station,
    previously it used share memory & hardware fast-path between L1 & L2.
    Now we use PCIE & software fast-path(ODP or DPDK).
    There is no requirement of bandwidth allocation between L1&L2,
    so we only need PF mode, and deploy the pod with PF as a daemon.

Change-Id: I587c334d8025d71376916d5adaaa0569a9d8a429
Jira-Id: ENTOS-254