### PR TITLE
disable releaseVF & releasePF on Kata Container

### DIFF
--- a/sriov/lock.go
+++ b/sriov/lock.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+var defaultDeviceDir = "/var/lib/cni/devices"
+
+type FileLocker struct {
+	f *os.File
+}
+
+func NewFileLocker(vf int) (*FileLocker, error) {
+	if err := os.MkdirAll(defaultDeviceDir, 0644); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("%s/%d.lock", defaultDeviceDir, vf)
+
+	file, err := os.Open(path)
+	if err == nil {
+		return &FileLocker{file}, nil
+	}
+
+	newfile, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &FileLocker{newfile}, nil
+
+}
+
+// Close closes underlying file
+func (l *FileLocker) Close() error {
+	return l.f.Close()
+}
+
+// Lock acquires an exclusive lock
+func (l *FileLocker) Lock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+// Unlock releases the lock
+func (l *FileLocker) Unlock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+}

--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -144,9 +144,11 @@ func releasePF(conf *SriovConf, ifName string, netns ns.NetNS) error {
 	return netns.Do(func(_ ns.NetNS) error {
 
 		// get PF device
+		// for kata containers, the network interface bind back to host by runtime
+		// hence we'll skip this "failed to lookup device' error
 		master, err := netlink.LinkByName(ifName)
 		if err != nil {
-			return fmt.Errorf("failed to lookup device %s: %v", ifName, err)
+			return nil
 		}
 
 		masterName := conf.Net.Master
@@ -181,9 +183,11 @@ func releaseVF(conf *SriovConf, ifName string, netns ns.NetNS) error {
 	return netns.Do(func(_ ns.NetNS) error {
 
 		// get VF device
+		// for kata containers, the network interface bind back to host by runtime
+		// hence we'll skip this "failed to lookup device' error
 		vfDev, err := netlink.LinkByName(ifName)
 		if err != nil {
-			return fmt.Errorf("failed to lookup device %s: %v", ifName, err)
+			return nil
 		}
 
 		// device name in init netns


### PR DESCRIPTION
In order to enable SRIOV on Kata Container, we've added this patch to
disable releaseVF and releasePF from network netnamespace. As this
device was release it back to host by kata container itself.

Signed-off-by: Qingyuan Hou <qingyuan.hou@linux.alibaba.com>